### PR TITLE
Remove regression tests involving lb, lbu, lh, and lhu instructions.

### DIFF
--- a/tests/testlists/random_tests.tl
+++ b/tests/testlists/random_tests.tl
@@ -21,13 +21,8 @@ test_lui
 test_beq
 test_lui
 test_auipc
-test_more_mem_1
 test_more_mem_2
 test_more_mem_3
-test_more_mem_4
-test_more_mem_5
-test_more_mem_6
-test_more_mem_7
 test_bne
 test_bge
 test_bltu

--- a/tests/testlists/unit_tests.tl
+++ b/tests/testlists/unit_tests.tl
@@ -11,10 +11,6 @@ bltu
 bne
 jalr
 jal
-lb
-lbu
-lh
-lhu
 lui
 lw
 ori


### PR DESCRIPTION
lb, lbu, lh, and lhu instructions do not need to implemented for the WISC-V project.  This PR removes those tests from the regression test lists.